### PR TITLE
Makefile GCC Flag bugfix

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -6,7 +6,7 @@ ASM_OBJECTS = $(ASM_SOURCES:.x86=.xo)
 BINARY = kernel.img
 
 CC = gcc
-CFLAGS = -m32 -Wall -Werror -std=c11 -fno-stack-protector -fno-builtin
+CFLAGS = -m32 -Wall -Werror -std=c11 -ffreestanding
 ASM = nasm
 ASM_FLAGS = -f elf32
 LD = ld


### PR DESCRIPTION
# Makefile GCC Flags

**_-fno-builtin**_
Using -fno-builtin is an OS dev no-no. it removes all of the runtime library (even the parts you want to keep that aren't os dependent) they also make it impossible to use headers like stdbool, stdint, stdarg, and iso646.
By using -ffreestanding, you gain these back without sacrificing anything in return.

**_-fno-stack-protector**_
I don't know who told you to use this. It hasn't done anything since gcc 2.5
